### PR TITLE
Restore returning the baseline in the measureText function.

### DIFF
--- a/packages/utils/geometry/shape.ts
+++ b/packages/utils/geometry/shape.ts
@@ -311,6 +311,7 @@ export const getClosedCurveShape = (
   }
 
   const polygonPoints = pointsOnBezierCurves(points, 10, 5).map((p) =>
+    // @ts-ignore
     transform(p),
   );
 


### PR DESCRIPTION
I want to know why the baseline was removed from the measureText function, but it is still used in _measureText within the obsidian-excalidraw-plugin.

I want to add support for text to svgToExcalidraw, where the baseline is needed.