### PR TITLE
Fix drop between frames bug

### DIFF
--- a/packages/element/src/frame.ts
+++ b/packages/element/src/frame.ts
@@ -580,7 +580,8 @@ export const addElementsToFrame = <T extends ElementsMapOrArray>(
       continue;
     }
 
-    if (element.frameId && element.frameId !== frame.id) {
+    // skip elements already in target frame
+    if (element.frameId && element.frameId === frame.id) {
       continue;
     }
 


### PR DESCRIPTION
This fixes moving an element from a frame into another, currently the frameID remains as the previous frame and so the element can no longer be clicked (due to clipped outside the bounds of the frame) etc

Reference: https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/2799

Best regards