### PR TITLE
Add typed Obsidian host boundary

### DIFF
--- a/packages/common/src/commonObsidianHost.test.ts
+++ b/packages/common/src/commonObsidianHost.test.ts
@@ -6,7 +6,11 @@ import {
   type ObsidianCommonHostAdapter,
   type ObsidianCommonHostDisposer,
 } from "./commonObsidianHost";
-import { getAreaLimit, getWidthHeightLimit } from "./commonObsidianUtils";
+import {
+  getAreaLimit,
+  getObsidianDeviceInfo,
+  getWidthHeightLimit,
+} from "./commonObsidianUtils";
 
 const createFakeHost = (
   areaLimit: number,
@@ -70,6 +74,22 @@ describe("Obsidian common host registry", () => {
 
     expect(getAreaLimit()).toBe(12_345);
     expect(getWidthHeightLimit()).toBe(6_789);
+  });
+
+  it("supplies device capabilities without loading the plugin", () => {
+    configure(createFakeHost(123));
+
+    expect(getObsidianDeviceInfo()).toEqual({
+      isDesktop: true,
+      isPhone: false,
+      isTablet: false,
+      isMobile: false,
+      isLinux: false,
+      isMacOS: true,
+      isWindows: false,
+      isIOS: false,
+      isAndroid: false,
+    });
   });
 
   it("disposes the active registration idempotently", () => {

--- a/packages/common/src/commonObsidianHost.test.ts
+++ b/packages/common/src/commonObsidianHost.test.ts
@@ -9,9 +9,17 @@ import {
 import {
   getAreaLimit,
   getDesktopUIMode,
+  getHighlightColor,
   getObsidianDeviceInfo,
+  getPreferredUIMode,
   getWidthHeightLimit,
 } from "./commonObsidianUtils";
+
+const preferredModes = {
+  phone: "mobile",
+  tablet: "compact",
+  desktop: "full",
+} as const;
 
 const createFakeHost = (
   areaLimit: number,
@@ -105,6 +113,33 @@ describe("Obsidian common host registry", () => {
       getDesktopUIMode: () => "unsupported",
     } as unknown as ObsidianCommonHostAdapter);
     expect(getDesktopUIMode()).toBe("tray");
+  });
+
+  it("supplies preferred UI modes for every form factor without loading the plugin", () => {
+    configure({
+      ...createFakeHost(123),
+      getPreferredUIMode: (formFactor) => preferredModes[formFactor],
+    });
+
+    expect(getPreferredUIMode("phone")).toBe("mobile");
+    expect(getPreferredUIMode("tablet")).toBe("compact");
+    expect(getPreferredUIMode("desktop")).toBe("full");
+  });
+
+  it("forwards highlight inputs and default opacity without loading the plugin", () => {
+    const highlight = vi.fn(
+      (sceneBackgroundColor: string, opacity: number) =>
+        `${sceneBackgroundColor}:${opacity}`,
+    );
+    configure({
+      ...createFakeHost(123),
+      getHighlightColor: highlight,
+    });
+
+    expect(getHighlightColor("#ffffff", 0.4)).toBe("#ffffff:0.4");
+    expect(getHighlightColor("#000000")).toBe("#000000:1");
+    expect(highlight).toHaveBeenNthCalledWith(1, "#ffffff", 0.4);
+    expect(highlight).toHaveBeenNthCalledWith(2, "#000000", 1);
   });
 
   it("disposes the active registration idempotently", () => {

--- a/packages/common/src/commonObsidianHost.test.ts
+++ b/packages/common/src/commonObsidianHost.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./commonObsidianHost";
 import {
   getAreaLimit,
+  getDesktopUIMode,
   getObsidianDeviceInfo,
   getWidthHeightLimit,
 } from "./commonObsidianUtils";
@@ -90,6 +91,20 @@ describe("Obsidian common host registry", () => {
       isIOS: false,
       isAndroid: false,
     });
+  });
+
+  it("supplies and normalizes the desktop UI mode without loading the plugin", () => {
+    configure({
+      ...createFakeHost(123),
+      getDesktopUIMode: () => "compact",
+    });
+    expect(getDesktopUIMode()).toBe("compact");
+
+    configure({
+      ...createFakeHost(123),
+      getDesktopUIMode: () => "unsupported",
+    } as unknown as ObsidianCommonHostAdapter);
+    expect(getDesktopUIMode()).toBe("tray");
   });
 
   it("disposes the active registration idempotently", () => {

--- a/packages/common/src/commonObsidianHost.test.ts
+++ b/packages/common/src/commonObsidianHost.test.ts
@@ -1,0 +1,105 @@
+import {
+  configureObsidianCommonHost,
+  getObsidianCommonHost,
+  hasObsidianCommonHost,
+  OBSIDIAN_COMMON_HOST_PROTOCOL_VERSION,
+  type ObsidianCommonHostAdapter,
+  type ObsidianCommonHostDisposer,
+} from "./commonObsidianHost";
+import { getAreaLimit, getWidthHeightLimit } from "./commonObsidianUtils";
+
+const createFakeHost = (
+  areaLimit: number,
+  widthHeightLimit = 32_767,
+): ObsidianCommonHostAdapter => ({
+  protocolVersion: OBSIDIAN_COMMON_HOST_PROTOCOL_VERSION,
+  getDeviceInfo: () => ({
+    isDesktop: true,
+    isPhone: false,
+    isTablet: false,
+    isMobile: false,
+    isLinux: false,
+    isMacOS: true,
+    isWindows: false,
+    isIOS: false,
+    isAndroid: false,
+  }),
+  getDesktopUIMode: () => "tray",
+  getPreferredUIMode: (formFactor) =>
+    formFactor === "phone" ? "mobile" : "tray",
+  getCanvasLimits: () => ({ areaLimit, widthHeightLimit }),
+  getHighlightColor: (_sceneBackgroundColor, opacity) =>
+    `rgba(0,118,255,${opacity})`,
+});
+
+describe("Obsidian common host registry", () => {
+  const disposers: ObsidianCommonHostDisposer[] = [];
+
+  afterEach(() => {
+    while (disposers.length > 0) {
+      disposers.pop()?.();
+    }
+  });
+
+  const configure = (adapter: ObsidianCommonHostAdapter) => {
+    const dispose = configureObsidianCommonHost(adapter);
+    disposers.push(dispose);
+    return dispose;
+  };
+
+  it("starts without requiring an Obsidian plugin or global app", () => {
+    expect(getObsidianCommonHost()).toBeNull();
+    expect(hasObsidianCommonHost()).toBe(false);
+  });
+
+  it("exposes capabilities from a configured structural fake", () => {
+    configure(createFakeHost(123));
+
+    const host = getObsidianCommonHost();
+    expect(host?.getCanvasLimits()).toEqual({
+      areaLimit: 123,
+      widthHeightLimit: 32_767,
+    });
+    expect(host?.getPreferredUIMode("phone")).toBe("mobile");
+    expect(host?.getHighlightColor("#ffffff", 0.5)).toBe("rgba(0,118,255,0.5)");
+    expect(hasObsidianCommonHost()).toBe(true);
+  });
+
+  it("supplies both render-canvas limits without loading the plugin", () => {
+    configure(createFakeHost(12_345, 6_789));
+
+    expect(getAreaLimit()).toBe(12_345);
+    expect(getWidthHeightLimit()).toBe(6_789);
+  });
+
+  it("disposes the active registration idempotently", () => {
+    const dispose = configure(createFakeHost(123));
+
+    dispose();
+    dispose();
+
+    expect(getObsidianCommonHost()).toBeNull();
+    expect(hasObsidianCommonHost()).toBe(false);
+  });
+
+  it("does not let a stale disposer clear a newer registration", () => {
+    const disposeFirst = configure(createFakeHost(123));
+    configure(createFakeHost(456));
+
+    disposeFirst();
+
+    expect(getObsidianCommonHost()?.getCanvasLimits().areaLimit).toBe(456);
+  });
+
+  it("rejects an unsupported runtime protocol", () => {
+    const incompatibleHost = {
+      ...createFakeHost(123),
+      protocolVersion: 2,
+    } as unknown as ObsidianCommonHostAdapter;
+
+    expect(() => configureObsidianCommonHost(incompatibleHost)).toThrow(
+      "Unsupported Obsidian common host protocol: 2",
+    );
+    expect(getObsidianCommonHost()).toBeNull();
+  });
+});

--- a/packages/common/src/commonObsidianHost.test.ts
+++ b/packages/common/src/commonObsidianHost.test.ts
@@ -65,6 +65,16 @@ describe("Obsidian common host registry", () => {
     expect(hasObsidianCommonHost()).toBe(false);
   });
 
+  it("uses safe defaults when no host is configured", () => {
+    expect(getObsidianDeviceInfo()).toBeNull();
+    expect(getDesktopUIMode()).toBe("tray");
+    expect(getPreferredUIMode("phone")).toBe("mobile");
+    expect(getPreferredUIMode("tablet")).toBe("tray");
+    expect(getAreaLimit()).toBe(16_777_216);
+    expect(getWidthHeightLimit()).toBe(32_767);
+    expect(getHighlightColor("#ffffff", 0.5)).toBe("rgba(0,118,255,0.5)");
+  });
+
   it("exposes capabilities from a configured structural fake", () => {
     configure(createFakeHost(123));
 

--- a/packages/common/src/commonObsidianHost.ts
+++ b/packages/common/src/commonObsidianHost.ts
@@ -1,0 +1,111 @@
+import type { EditorInterface, StylesPanelMode } from "./editorInterface";
+
+/**
+ * Obsidian-only host contract shared by the fork's common and element layers.
+ *
+ * @remarks
+ * This module is a deliberately ringfenced fork extension. It defines a
+ * dependency-inversion boundary without importing Obsidian or the consuming
+ * plugin. The host is registered once for an evaluated window-scoped runtime;
+ * component instances must not install or dispose it.
+ *
+ * Author: zsviczian
+ *
+ * @see https://github.com/zsviczian/obsidian-excalidraw-plugin
+ */
+
+/** Runtime protocol understood by this version of the fork. */
+export const OBSIDIAN_COMMON_HOST_PROTOCOL_VERSION = 1 as const;
+
+/** Device capabilities supplied by the Obsidian host. */
+export type ObsidianDeviceType = Readonly<{
+  isDesktop: boolean;
+  isPhone: boolean;
+  isTablet: boolean;
+  isMobile: boolean;
+  isLinux: boolean;
+  isMacOS: boolean;
+  isWindows: boolean;
+  isIOS: boolean;
+  isAndroid: boolean;
+}>;
+
+/** Canvas limits supplied by the host for the current platform. */
+export type ObsidianCanvasLimits = Readonly<{
+  areaLimit: number;
+  widthHeightLimit: number;
+}>;
+
+/**
+ * Narrow host capabilities required below the Excalidraw component layer.
+ *
+ * @remarks
+ * Keep this contract semantic: do not expose the plugin instance, its settings
+ * object, or an active view. Excalidraw-specific and editor-instance services
+ * belong in higher-level adapters rather than this common-package boundary.
+ */
+export interface ObsidianCommonHostAdapter {
+  readonly protocolVersion: typeof OBSIDIAN_COMMON_HOST_PROTOCOL_VERSION;
+
+  getDeviceInfo(): ObsidianDeviceType | null;
+
+  getDesktopUIMode(): StylesPanelMode;
+
+  getPreferredUIMode(
+    formFactor: EditorInterface["formFactor"],
+  ): StylesPanelMode;
+
+  getCanvasLimits(): ObsidianCanvasLimits;
+
+  getHighlightColor(sceneBackgroundColor: string, opacity: number): string;
+}
+
+/** Idempotent cleanup returned when a host adapter is configured. */
+export type ObsidianCommonHostDisposer = () => void;
+
+type HostRegistration = Readonly<{
+  adapter: ObsidianCommonHostAdapter;
+  token: symbol;
+}>;
+
+let activeRegistration: HostRegistration | null = null;
+
+/**
+ * Configures the common Obsidian host for this evaluated runtime.
+ *
+ * @returns An idempotent disposer. A disposer from an older registration will
+ * not clear a newer host, which makes overlapping teardown safe.
+ */
+export const configureObsidianCommonHost = (
+  adapter: ObsidianCommonHostAdapter,
+): ObsidianCommonHostDisposer => {
+  if (adapter.protocolVersion !== OBSIDIAN_COMMON_HOST_PROTOCOL_VERSION) {
+    throw new Error(
+      `Unsupported Obsidian common host protocol: ${String(
+        adapter.protocolVersion,
+      )}`,
+    );
+  }
+
+  const token = Symbol("obsidian-common-host");
+  activeRegistration = { adapter, token };
+  let disposed = false;
+
+  return () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+
+    if (activeRegistration?.token === token) {
+      activeRegistration = null;
+    }
+  };
+};
+
+/** Returns the configured common host, or `null` outside Obsidian. */
+export const getObsidianCommonHost = (): ObsidianCommonHostAdapter | null =>
+  activeRegistration?.adapter ?? null;
+
+/** Returns whether this evaluated runtime currently has an Obsidian host. */
+export const hasObsidianCommonHost = (): boolean => activeRegistration !== null;

--- a/packages/common/src/commonObsidianUtils.ts
+++ b/packages/common/src/commonObsidianUtils.ts
@@ -1,18 +1,13 @@
+import {
+  getObsidianCommonHost,
+  type ObsidianDeviceType,
+} from "./commonObsidianHost";
+
 import type { EditorInterface, StylesPanelMode } from "./editorInterface";
 
-//zsviczian, my dirty little secrets. These are hacks I am not proud of...
-export type ObsidianDeviceType = {
-  isDesktop: boolean;
-  isPhone: boolean;
-  isTablet: boolean;
-  isMobile: boolean;
-  isLinux: boolean;
-  isMacOS: boolean;
-  isWindows: boolean;
-  isIOS: boolean;
-  isAndroid: boolean;
-};
+export type { ObsidianDeviceType } from "./commonObsidianHost";
 
+//zsviczian, my dirty little secrets. These are hacks I am not proud of...
 let ObsidianDevice: ObsidianDeviceType | null = null;
 
 //zsviczian, my dirty little secrets. These are hacks I am not proud of...
@@ -76,11 +71,19 @@ export const getPreferredUIMode = (
 };
 
 export function getAreaLimit() {
-  return getHostPlugin().excalidrawConfig.areaLimit ?? 16777216;
+  return (
+    getObsidianCommonHost()?.getCanvasLimits().areaLimit ??
+    getHostPlugin().excalidrawConfig.areaLimit ??
+    16777216
+  );
 }
 
 export function getWidthHeightLimit() {
-  return getHostPlugin().excalidrawConfig.widthHeightLimit ?? 32767;
+  return (
+    getObsidianCommonHost()?.getCanvasLimits().widthHeightLimit ??
+    getHostPlugin().excalidrawConfig.widthHeightLimit ??
+    32767
+  );
 }
 
 export function getHighlightColor(

--- a/packages/common/src/commonObsidianUtils.ts
+++ b/packages/common/src/commonObsidianUtils.ts
@@ -72,6 +72,11 @@ export const getDesktopUIMode = () => {
 export const getPreferredUIMode = (
   formFactor: EditorInterface["formFactor"],
 ): StylesPanelMode => {
+  const host = getObsidianCommonHost();
+  if (host) {
+    return host.getPreferredUIMode(formFactor);
+  }
+
   if (formFactor === "phone") {
     return getHostPlugin().settings.phoneUIMode;
   }
@@ -103,8 +108,13 @@ export function getHighlightColor(
   sceneBgColor: string,
   opacity: number = 1,
 ): string {
+  const fallbackColor = `rgba(0,118,255,${opacity})`;
+  const host = getObsidianCommonHost();
+  if (host) {
+    return host.getHighlightColor(sceneBgColor, opacity) ?? fallbackColor;
+  }
+
   return (
-    getHostPlugin().getHighlightColor(sceneBgColor, opacity) ??
-    `rgba(0,118,255,${opacity})`
+    getHostPlugin().getHighlightColor(sceneBgColor, opacity) ?? fallbackColor
   );
 }

--- a/packages/common/src/commonObsidianUtils.ts
+++ b/packages/common/src/commonObsidianUtils.ts
@@ -7,6 +7,12 @@ import type { EditorInterface, StylesPanelMode } from "./editorInterface";
 
 export type { ObsidianDeviceType } from "./commonObsidianHost";
 
+const normalizeStylesPanelMode = (mode: unknown): StylesPanelMode =>
+  typeof mode === "string" &&
+  ["tray", "full", "compact", "mobile"].includes(mode)
+    ? (mode as StylesPanelMode)
+    : "tray";
+
 //zsviczian, my dirty little secrets. These are hacks I am not proud of...
 let ObsidianDevice: ObsidianDeviceType | null = null;
 
@@ -49,16 +55,18 @@ export const getObsidianDeviceInfo = () => {
 };
 
 export const getDesktopUIMode = () => {
+  const host = getObsidianCommonHost();
+  if (host) {
+    return normalizeStylesPanelMode(host.getDesktopUIMode());
+  }
+
   //@ts-ignore
   const obsidianPlugin = app.plugins.plugins["obsidian-excalidraw-plugin"];
   if (!obsidianPlugin) {
     return "tray";
   }
 
-  const desktopUIMode = obsidianPlugin.getPreferredUIMode();
-  return ["tray", "full", "compact", "mobile"].includes(desktopUIMode)
-    ? desktopUIMode
-    : "tray";
+  return normalizeStylesPanelMode(obsidianPlugin.getPreferredUIMode());
 };
 
 export const getPreferredUIMode = (

--- a/packages/common/src/commonObsidianUtils.ts
+++ b/packages/common/src/commonObsidianUtils.ts
@@ -1,7 +1,4 @@
-import {
-  getObsidianCommonHost,
-  type ObsidianDeviceType,
-} from "./commonObsidianHost";
+import { getObsidianCommonHost } from "./commonObsidianHost";
 
 import type { EditorInterface, StylesPanelMode } from "./editorInterface";
 
@@ -13,95 +10,28 @@ const normalizeStylesPanelMode = (mode: unknown): StylesPanelMode =>
     ? (mode as StylesPanelMode)
     : "tray";
 
-//zsviczian, my dirty little secrets. These are hacks I am not proud of...
-let ObsidianDevice: ObsidianDeviceType | null = null;
-
-//zsviczian, my dirty little secrets. These are hacks I am not proud of...
-export let hostPlugin: any = null;
-
-export function destroyObsidianUtils() {
-  hostPlugin = null;
-}
-
-export function initializeObsidianUtils() {
-  //@ts-ignore
-  hostPlugin = app.plugins.plugins["obsidian-excalidraw-plugin"];
-}
-
-export function getHostPlugin() {
-  if (!hostPlugin) {
-    initializeObsidianUtils();
-  }
-  return hostPlugin;
-}
-
-export const getObsidianDeviceInfo = () => {
-  const host = getObsidianCommonHost();
-  if (host) {
-    return host.getDeviceInfo();
-  }
-
-  if (ObsidianDevice) {
-    return ObsidianDevice;
-  }
-  //@ts-ignore
-  const obsidianPlugin = app.plugins.plugins["obsidian-excalidraw-plugin"];
-  if (!obsidianPlugin) {
-    return null;
-  }
-  return (ObsidianDevice = {
-    ...(obsidianPlugin.getObsidianDevice() as ObsidianDeviceType),
-  });
-};
+export const getObsidianDeviceInfo = () =>
+  getObsidianCommonHost()?.getDeviceInfo() ?? null;
 
 export const getDesktopUIMode = () => {
-  const host = getObsidianCommonHost();
-  if (host) {
-    return normalizeStylesPanelMode(host.getDesktopUIMode());
-  }
-
-  //@ts-ignore
-  const obsidianPlugin = app.plugins.plugins["obsidian-excalidraw-plugin"];
-  if (!obsidianPlugin) {
-    return "tray";
-  }
-
-  return normalizeStylesPanelMode(obsidianPlugin.getPreferredUIMode());
+  return normalizeStylesPanelMode(getObsidianCommonHost()?.getDesktopUIMode());
 };
 
 export const getPreferredUIMode = (
   formFactor: EditorInterface["formFactor"],
 ): StylesPanelMode => {
-  const host = getObsidianCommonHost();
-  if (host) {
-    return host.getPreferredUIMode(formFactor);
-  }
-
-  if (formFactor === "phone") {
-    return getHostPlugin().settings.phoneUIMode;
-  }
-
-  if (formFactor === "tablet") {
-    return getHostPlugin().settings.tabletUIMode;
-  }
-
-  return getHostPlugin().settings.desktopUIMode;
+  return (
+    getObsidianCommonHost()?.getPreferredUIMode(formFactor) ??
+    (formFactor === "phone" ? "mobile" : "tray")
+  );
 };
 
 export function getAreaLimit() {
-  return (
-    getObsidianCommonHost()?.getCanvasLimits().areaLimit ??
-    getHostPlugin().excalidrawConfig.areaLimit ??
-    16777216
-  );
+  return getObsidianCommonHost()?.getCanvasLimits().areaLimit ?? 16777216;
 }
 
 export function getWidthHeightLimit() {
-  return (
-    getObsidianCommonHost()?.getCanvasLimits().widthHeightLimit ??
-    getHostPlugin().excalidrawConfig.widthHeightLimit ??
-    32767
-  );
+  return getObsidianCommonHost()?.getCanvasLimits().widthHeightLimit ?? 32767;
 }
 
 export function getHighlightColor(
@@ -113,8 +43,5 @@ export function getHighlightColor(
   if (host) {
     return host.getHighlightColor(sceneBgColor, opacity) ?? fallbackColor;
   }
-
-  return (
-    getHostPlugin().getHighlightColor(sceneBgColor, opacity) ?? fallbackColor
-  );
+  return fallbackColor;
 }

--- a/packages/common/src/commonObsidianUtils.ts
+++ b/packages/common/src/commonObsidianUtils.ts
@@ -30,6 +30,11 @@ export function getHostPlugin() {
 }
 
 export const getObsidianDeviceInfo = () => {
+  const host = getObsidianCommonHost();
+  if (host) {
+    return host.getDeviceInfo();
+  }
+
   if (ObsidianDevice) {
     return ObsidianDevice;
   }

--- a/packages/common/src/editorInterface.ts
+++ b/packages/common/src/editorInterface.ts
@@ -4,7 +4,7 @@ export type StylesPanelMode = "compact" | "full" | "mobile" | "tray"; //zsviczia
 
 export type EditorInterface = Readonly<{
   formFactor: "phone" | "tablet" | "desktop";
-  desktopUIMode: "compact" | "full" | "tray" | "mobile"; //zsviczian
+  desktopUIMode: StylesPanelMode; //zsviczian
   userAgent: Readonly<{
     isMobileDevice: boolean;
     platform: "ios" | "android" | "other" | "unknown";

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -13,6 +13,7 @@ export * from "./utils";
 export * from "./emitter";
 export * from "./appEventBus";
 export * from "./editorInterface";
+export * from "./commonObsidianHost";
 export * from "./commonObsidianUtils";
 export * from "./versionedSnapshotStore";
 export { Debug } from "../debug";

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -429,6 +429,20 @@ import { LassoTrail } from "../lasso";
 import { EraserTrail } from "../eraser";
 import { getShortcutKey } from "../shortcut";
 import { tryParseSpreadsheet } from "../charts";
+import {
+  allowDoubleTapEraser,
+  disableDoubleClickTextEditing,
+  getMaxZoom,
+  getZoomStep,
+  hideFreedrawPenmodeCursor,
+  isTouchInPenMode,
+  isPanWithRightMouseEnabled,
+  shouldDisableZoom,
+  isContextMenuDisabled,
+  refreshAllArrows,
+  syncElementLinkWithText,
+  getSharedMermaidInstance,
+} from "../obsidianUtils";
 
 import ConvertElementTypePopup, {
   getConversionTypeFromElements,
@@ -503,8 +517,6 @@ import type {
 } from "../types";
 import type { RoughCanvas } from "roughjs/bin/canvas";
 import type { Action, ActionName, ActionResult } from "../actions/types";
-import { allowDoubleTapEraser, disableDoubleClickTextEditing, getExcalidrawContentEl, getMaxZoom, getZoomStep, hideFreedrawPenmodeCursor, isTouchInPenMode, isPanWithRightMouseEnabled, shouldDisableZoom, isContextMenuDisabled, refreshAllArrows, syncElementLinkWithText, getSharedMermaidInstance } from "../obsidianUtils";
-import { initializeObsidianUtils } from "@excalidraw/common";
 import { getTooltipDiv } from "./Tooltip";
 import { getFontSize } from "../actions/actionProperties";
 
@@ -883,7 +895,6 @@ class App extends React.Component<AppProps, AppState> {
     this.stylesPanelMode = deriveStylesPanelMode(this.editorInterface);
 
     this.id = nanoid();
-    initializeObsidianUtils();
     this.library = new Library(this);
     this.actionManager = new ActionManager(
       this.syncActionResult,
@@ -2283,9 +2294,10 @@ class App extends React.Component<AppProps, AppState> {
                 : FRAME_STYLE.nameColorLightTheme,
               overflow: "hidden",
               maxWidth: `${
-                getExcalidrawContentEl().clientWidth -
+                (this.excalidrawContainerRef.current?.clientWidth ??
+                  document.body.clientWidth) -
                 x1 -
-                FRAME_NAME_EDIT_PADDING //zsviczian was document.body
+                FRAME_NAME_EDIT_PADDING //zsviczian -- use this editor's container in multi-view/popout layouts
               }px`,
             }}
             size={frameNameInEdit.length + 1 || 1}

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -448,7 +448,6 @@ export {
   exportToClipboard,
 } from "@excalidraw/utils/export";
 
-
 export { getCommonBoundingBox } from "@excalidraw/element/bounds"; //zsviczian
 export { getMaximumGroups } from "@excalidraw/element/groups"; //zsviczian
 export { measureText } from "@excalidraw/element/textMeasurements"; //zsviczian
@@ -497,6 +496,8 @@ export {
   viewportCoordsToSceneCoords,
   getFormFactor,
   safelyParseJSON, //zsviczian
+  configureObsidianCommonHost, //zsviczian
+  OBSIDIAN_COMMON_HOST_PROTOCOL_VERSION, //zsviczian
   destroyObsidianUtils, //zsviczian
   throttleRAF,
 } from "@excalidraw/common";

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -600,3 +600,8 @@ export function useExcalidrawStateValue(
 export { _useOnAppStateChange as useOnExcalidrawStateChange };
 
 export { applyDarkModeFilter, getStrokeWidthByKey };
+
+export {
+  configureObsidianExcalidrawHost,
+  OBSIDIAN_EXCALIDRAW_HOST_PROTOCOL_VERSION,
+} from "./obsidianExcalidrawHost"; //zsviczian

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -498,7 +498,6 @@ export {
   safelyParseJSON, //zsviczian
   configureObsidianCommonHost, //zsviczian
   OBSIDIAN_COMMON_HOST_PROTOCOL_VERSION, //zsviczian
-  destroyObsidianUtils, //zsviczian
   throttleRAF,
 } from "@excalidraw/common";
 

--- a/packages/excalidraw/obsidianExcalidrawHost.test.ts
+++ b/packages/excalidraw/obsidianExcalidrawHost.test.ts
@@ -1,0 +1,114 @@
+import {
+  configureObsidianExcalidrawHost,
+  getObsidianExcalidrawHost,
+  hasObsidianExcalidrawHost,
+  OBSIDIAN_EXCALIDRAW_HOST_PROTOCOL_VERSION,
+  type ObsidianExcalidrawHostAdapter,
+  type ObsidianExcalidrawHostDisposer,
+} from "./obsidianExcalidrawHost";
+import {
+  allowDoubleTapEraser,
+  disableDoubleClickTextEditing,
+  getMaxZoom,
+  getZoomMax,
+  getZoomMin,
+  getZoomStep,
+  hideFreedrawPenmodeCursor,
+  isContextMenuDisabled,
+  isPanWithRightMouseEnabled,
+  isTouchInPenMode,
+  syncElementLinkWithText,
+} from "./obsidianUtils";
+
+import type { AppState } from "./types";
+
+const createFakeHost = (): ObsidianExcalidrawHostAdapter => ({
+  protocolVersion: OBSIDIAN_EXCALIDRAW_HOST_PROTOCOL_VERSION,
+  isDoubleTapEraserEnabled: () => true,
+  isRightClickPanEnabled: () => true,
+  getZoomToFitMaxLevel: () => 2.5,
+  isPenModeCrosshairVisible: () => false,
+  isSingleFingerPanningEnabled: () => true,
+  isDoubleClickTextEditingDisabled: () => true,
+  getZoomStep: () => 0.125,
+  getZoomMin: () => 0.2,
+  getZoomMax: () => 42,
+  isContextMenuDisabled: () => true,
+  shouldSyncElementLinkWithText: () => false,
+});
+
+describe("Obsidian Excalidraw host registry", () => {
+  const disposers: ObsidianExcalidrawHostDisposer[] = [];
+
+  afterEach(() => {
+    while (disposers.length > 0) {
+      disposers.pop()?.();
+    }
+  });
+
+  const configure = (adapter: ObsidianExcalidrawHostAdapter) => {
+    const dispose = configureObsidianExcalidrawHost(adapter);
+    disposers.push(dispose);
+    return dispose;
+  };
+
+  it("starts without requiring an Obsidian plugin or global app", () => {
+    expect(getObsidianExcalidrawHost()).toBeNull();
+    expect(hasObsidianExcalidrawHost()).toBe(false);
+  });
+
+  it("routes settings-only production helpers through a structural fake", () => {
+    configure(createFakeHost());
+
+    expect(allowDoubleTapEraser()).toBe(true);
+    expect(isPanWithRightMouseEnabled()).toBe(true);
+    expect(getMaxZoom()).toBe(2.5);
+    expect(hideFreedrawPenmodeCursor()).toBe(true);
+    expect(disableDoubleClickTextEditing()).toBe(true);
+    expect(getZoomStep()).toBe(0.125);
+    expect(getZoomMin()).toBe(0.2);
+    expect(getZoomMax()).toBe(42);
+    expect(isContextMenuDisabled()).toBe(true);
+    expect(syncElementLinkWithText()).toBe(false);
+  });
+
+  it("routes single-finger pen-mode panning through the structural fake", () => {
+    configure(createFakeHost());
+
+    expect(
+      isTouchInPenMode(
+        {
+          penMode: true,
+          activeTool: { type: "freedraw" },
+        } as AppState,
+        new MouseEvent("pointerdown"),
+      ),
+    ).toBe(true);
+  });
+
+  it("disposes registrations idempotently without clearing a newer host", () => {
+    const disposeFirst = configure(createFakeHost());
+    const newerHost = {
+      ...createFakeHost(),
+      getZoomMax: () => 84,
+    };
+    configure(newerHost);
+
+    disposeFirst();
+    disposeFirst();
+
+    expect(getObsidianExcalidrawHost()).toBe(newerHost);
+  });
+
+  it("rejects an unsupported runtime protocol", () => {
+    const incompatibleHost = {
+      ...createFakeHost(),
+      protocolVersion: 2,
+    } as unknown as ObsidianExcalidrawHostAdapter;
+
+    expect(() => configureObsidianExcalidrawHost(incompatibleHost)).toThrow(
+      "Unsupported Obsidian Excalidraw host protocol: 2",
+    );
+    expect(getObsidianExcalidrawHost()).toBeNull();
+  });
+});

--- a/packages/excalidraw/obsidianExcalidrawHost.test.ts
+++ b/packages/excalidraw/obsidianExcalidrawHost.test.ts
@@ -8,8 +8,11 @@ import {
 } from "./obsidianExcalidrawHost";
 import {
   allowDoubleTapEraser,
+  attachInlineLinkSuggester,
   disableDoubleClickTextEditing,
+  fetchFontFromVault,
   getMaxZoom,
+  getSharedMermaidInstance,
   getZoomMax,
   getZoomMin,
   getZoomStep,
@@ -17,7 +20,9 @@ import {
   isContextMenuDisabled,
   isPanWithRightMouseEnabled,
   isTouchInPenMode,
+  runAction,
   syncElementLinkWithText,
+  t2,
 } from "./obsidianUtils";
 
 import type { AppState } from "./types";
@@ -35,6 +40,17 @@ const createFakeHost = (): ObsidianExcalidrawHostAdapter => ({
   getZoomMax: () => 42,
   isContextMenuDisabled: () => true,
   shouldSyncElementLinkWithText: () => false,
+  loadFontFromFile: async () => undefined,
+  getMermaid: async () => ({
+    loaded: false,
+    api: new Promise<never>(() => {}),
+  }),
+  runAction: () => {},
+  getLabel: (key) => key,
+  attachInlineLinkSuggester: () => ({
+    isBlockingKeys: () => false,
+    close: () => {},
+  }),
 });
 
 describe("Obsidian Excalidraw host registry", () => {
@@ -57,7 +73,25 @@ describe("Obsidian Excalidraw host registry", () => {
     expect(hasObsidianExcalidrawHost()).toBe(false);
   });
 
-  it("routes settings-only production helpers through a structural fake", () => {
+  it("uses safe defaults or an explicit error without a configured host", async () => {
+    expect(allowDoubleTapEraser()).toBe(false);
+    expect(isPanWithRightMouseEnabled()).toBe(false);
+    expect(getMaxZoom()).toBe(1);
+    expect(hideFreedrawPenmodeCursor()).toBe(false);
+    expect(disableDoubleClickTextEditing()).toBe(false);
+    expect(isContextMenuDisabled()).toBe(false);
+    expect(syncElementLinkWithText()).toBe(true);
+    expect(t2("COMP_FRAME")).toBe("COMP_FRAME");
+    expect(await fetchFontFromVault("vault/font.woff2")).toBeUndefined();
+    expect(() =>
+      attachInlineLinkSuggester(document.createElement("input")),
+    ).toThrow("Obsidian Excalidraw host is not configured");
+    await expect(getSharedMermaidInstance()).rejects.toThrow(
+      "Obsidian Excalidraw host is not configured",
+    );
+  });
+
+  it("routes settings production helpers through a structural fake", () => {
     configure(createFakeHost());
 
     expect(allowDoubleTapEraser()).toBe(true);
@@ -70,6 +104,50 @@ describe("Obsidian Excalidraw host registry", () => {
     expect(getZoomMax()).toBe(42);
     expect(isContextMenuDisabled()).toBe(true);
     expect(syncElementLinkWithText()).toBe(false);
+  });
+
+  it("routes plugin services through the structural fake", async () => {
+    const fontData = new ArrayBuffer(8);
+    const mermaid = {
+      loaded: false,
+      api: new Promise<never>(() => {}),
+    };
+    const blocker = {
+      isBlockingKeys: () => true,
+      close: vi.fn(),
+    };
+    const loadFontFromFile = vi.fn(async () => fontData);
+    const getMermaid = vi.fn(async () => mermaid);
+    const hostRunAction = vi.fn();
+    const getLabel = vi.fn((key: string) => `translated:${key}`);
+    const hostAttachInlineLinkSuggester = vi.fn(() => blocker);
+    configure({
+      ...createFakeHost(),
+      loadFontFromFile,
+      getMermaid,
+      runAction: hostRunAction,
+      getLabel,
+      attachInlineLinkSuggester: hostAttachInlineLinkSuggester,
+    });
+
+    expect(await fetchFontFromVault("vault/My%20Font.woff2")).toBe(fontData);
+    expect(loadFontFromFile).toHaveBeenCalledWith("My Font.woff2");
+    expect(await getSharedMermaidInstance()).toBe(mermaid);
+    expect(getMermaid).toHaveBeenCalledOnce();
+
+    runAction("card");
+    expect(hostRunAction).toHaveBeenCalledWith("card");
+    expect(t2("COMP_FRAME")).toBe("translated:COMP_FRAME");
+    expect(getLabel).toHaveBeenCalledWith("COMP_FRAME");
+
+    const input = document.createElement("textarea");
+    expect(attachInlineLinkSuggester(input)).toBe(blocker);
+    expect(hostAttachInlineLinkSuggester).toHaveBeenCalledWith(
+      input,
+      undefined,
+      null,
+      true,
+    );
   });
 
   it("routes single-finger pen-mode panning through the structural fake", () => {
@@ -103,11 +181,11 @@ describe("Obsidian Excalidraw host registry", () => {
   it("rejects an unsupported runtime protocol", () => {
     const incompatibleHost = {
       ...createFakeHost(),
-      protocolVersion: 2,
+      protocolVersion: 3,
     } as unknown as ObsidianExcalidrawHostAdapter;
 
     expect(() => configureObsidianExcalidrawHost(incompatibleHost)).toThrow(
-      "Unsupported Obsidian Excalidraw host protocol: 2",
+      "Unsupported Obsidian Excalidraw host protocol: 3",
     );
     expect(getObsidianExcalidrawHost()).toBeNull();
   });

--- a/packages/excalidraw/obsidianExcalidrawHost.ts
+++ b/packages/excalidraw/obsidianExcalidrawHost.ts
@@ -1,0 +1,84 @@
+/**
+ * Obsidian host contract for plugin-wide capabilities used by the Excalidraw
+ * package layer.
+ *
+ * @remarks
+ * This fork-only boundary intentionally exposes semantic scalar capabilities,
+ * not the plugin instance or its settings object. View-scoped services belong
+ * in a separate editor adapter and must not be added here.
+ *
+ * Author: zsviczian
+ *
+ * @see https://github.com/zsviczian/obsidian-excalidraw-plugin
+ */
+
+/** Runtime protocol understood by this version of the Excalidraw package. */
+export const OBSIDIAN_EXCALIDRAW_HOST_PROTOCOL_VERSION = 1 as const;
+
+/** Plugin-wide settings capabilities consumed by the Excalidraw package. */
+export interface ObsidianExcalidrawHostAdapter {
+  readonly protocolVersion: typeof OBSIDIAN_EXCALIDRAW_HOST_PROTOCOL_VERSION;
+
+  isDoubleTapEraserEnabled(): boolean;
+  isRightClickPanEnabled(): boolean;
+  getZoomToFitMaxLevel(): number;
+  isPenModeCrosshairVisible(): boolean;
+  isSingleFingerPanningEnabled(): boolean;
+  isDoubleClickTextEditingDisabled(): boolean;
+  getZoomStep(): number;
+  getZoomMin(): number;
+  getZoomMax(): number;
+  isContextMenuDisabled(): boolean;
+  shouldSyncElementLinkWithText(): boolean;
+}
+
+/** Idempotent cleanup returned when a package host is configured. */
+export type ObsidianExcalidrawHostDisposer = () => void;
+
+type HostRegistration = Readonly<{
+  adapter: ObsidianExcalidrawHostAdapter;
+  token: symbol;
+}>;
+
+let activeRegistration: HostRegistration | null = null;
+
+/**
+ * Configures the Obsidian host for this evaluated Excalidraw package runtime.
+ *
+ * @returns An idempotent, stale-registration-safe disposer.
+ */
+export const configureObsidianExcalidrawHost = (
+  adapter: ObsidianExcalidrawHostAdapter,
+): ObsidianExcalidrawHostDisposer => {
+  if (adapter.protocolVersion !== OBSIDIAN_EXCALIDRAW_HOST_PROTOCOL_VERSION) {
+    throw new Error(
+      `Unsupported Obsidian Excalidraw host protocol: ${String(
+        adapter.protocolVersion,
+      )}`,
+    );
+  }
+
+  const token = Symbol("obsidian-excalidraw-host");
+  activeRegistration = { adapter, token };
+  let disposed = false;
+
+  return () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+
+    if (activeRegistration?.token === token) {
+      activeRegistration = null;
+    }
+  };
+};
+
+/** Returns the configured package host, or `null` outside Obsidian. */
+export const getObsidianExcalidrawHost =
+  (): ObsidianExcalidrawHostAdapter | null =>
+    activeRegistration?.adapter ?? null;
+
+/** Returns whether this evaluated package runtime has an Obsidian host. */
+export const hasObsidianExcalidrawHost = (): boolean =>
+  activeRegistration !== null;

--- a/packages/excalidraw/obsidianExcalidrawHost.ts
+++ b/packages/excalidraw/obsidianExcalidrawHost.ts
@@ -3,19 +3,27 @@
  * package layer.
  *
  * @remarks
- * This fork-only boundary intentionally exposes semantic scalar capabilities,
- * not the plugin instance or its settings object. View-scoped services belong
- * in a separate editor adapter and must not be added here.
+ * This fork-only boundary intentionally exposes semantic capabilities, not the
+ * plugin instance or its settings object. View-scoped state must not be added
+ * here.
  *
  * Author: zsviczian
  *
  * @see https://github.com/zsviczian/obsidian-excalidraw-plugin
  */
 
-/** Runtime protocol understood by this version of the Excalidraw package. */
-export const OBSIDIAN_EXCALIDRAW_HOST_PROTOCOL_VERSION = 1 as const;
+import type { MermaidToExcalidrawLibProps } from "./components/TTDDialog/types";
 
-/** Plugin-wide settings capabilities consumed by the Excalidraw package. */
+/** Runtime protocol understood by this version of the Excalidraw package. */
+export const OBSIDIAN_EXCALIDRAW_HOST_PROTOCOL_VERSION = 2 as const;
+
+/** Keyboard-blocking lifecycle returned by the host's inline suggester. */
+export interface ObsidianKeyBlocker {
+  isBlockingKeys(): boolean;
+  close(): void;
+}
+
+/** Plugin-wide capabilities consumed by the Excalidraw package. */
 export interface ObsidianExcalidrawHostAdapter {
   readonly protocolVersion: typeof OBSIDIAN_EXCALIDRAW_HOST_PROTOCOL_VERSION;
 
@@ -30,6 +38,17 @@ export interface ObsidianExcalidrawHostAdapter {
   getZoomMax(): number;
   isContextMenuDisabled(): boolean;
   shouldSyncElementLinkWithText(): boolean;
+
+  loadFontFromFile(filename: string): Promise<ArrayBuffer | undefined>;
+  getMermaid(): Promise<MermaidToExcalidrawLibProps>;
+  runAction(action: "anyFile" | "LaTeX" | "card"): void;
+  getLabel(key: string): string;
+  attachInlineLinkSuggester(
+    inputEl: HTMLInputElement | HTMLTextAreaElement,
+    widthWrapper?: HTMLElement,
+    container?: HTMLDivElement | null,
+    suppressPlaceholder?: boolean,
+  ): ObsidianKeyBlocker;
 }
 
 /** Idempotent cleanup returned when a package host is configured. */

--- a/packages/excalidraw/obsidianUtils.ts
+++ b/packages/excalidraw/obsidianUtils.ts
@@ -47,6 +47,7 @@ import type { MermaidToExcalidrawResult } from "@excalidraw/mermaid-to-excalidra
 
 import { Fonts } from "./fonts";
 import { loadMermaidLib } from "./components/TTDDialog/MermaidToExcalidrawLib";
+import { getObsidianExcalidrawHost } from "./obsidianExcalidrawHost";
 
 import type { AppClassProperties, AppState } from "./types";
 
@@ -61,12 +62,20 @@ interface MermaidToExcalidrawLibProps {
 }
 
 export function allowDoubleTapEraser() {
+  const host = getObsidianExcalidrawHost();
+  if (host) {
+    return host.isDoubleTapEraserEnabled();
+  }
   return getHostPlugin().settings.penModeDoubleTapEraser;
 }
 
 //mfuria #329. Enable panning with right mouse button if host plugin setting allows
 export function isPanWithRightMouseEnabled(): boolean {
   try {
+    const host = getObsidianExcalidrawHost();
+    if (host) {
+      return !!host.isRightClickPanEnabled();
+    }
     return !!getHostPlugin().settings?.panWithRightMouseButton;
   } catch (e) {
     return false;
@@ -74,6 +83,10 @@ export function isPanWithRightMouseEnabled(): boolean {
 }
 
 export function getMaxZoom(): number {
+  const host = getObsidianExcalidrawHost();
+  if (host) {
+    return host.getZoomToFitMaxLevel() ?? 1;
+  }
   return getHostPlugin().settings.zoomToFitMaxLevel ?? 1;
 }
 
@@ -97,6 +110,10 @@ export function getExcalidrawContentEl(): HTMLElement {
 }
 
 export function hideFreedrawPenmodeCursor() {
+  const host = getObsidianExcalidrawHost();
+  if (host) {
+    return !host.isPenModeCrosshairVisible();
+  }
   return !getHostPlugin().settings.penModeCrosshairVisible;
 }
 
@@ -270,7 +287,11 @@ export function isTouchInPenMode(
   appState: AppState,
   event: React.PointerEvent<HTMLElement> | MouseEvent,
 ) {
-  if (!getHostPlugin().settings.penModeSingleFingerPanning) {
+  const host = getObsidianExcalidrawHost();
+  const isSingleFingerPanningEnabled = host
+    ? host.isSingleFingerPanningEnabled()
+    : getHostPlugin().settings.penModeSingleFingerPanning;
+  if (!isSingleFingerPanningEnabled) {
     return false;
   }
   //isReactPointerEvent typecheck is here only to please typescript, else event.pointerType === "touch" should be enough
@@ -311,15 +332,34 @@ export const intersectElementWithLine = (
 
 //disable double click
 export const disableDoubleClickTextEditing = () => {
+  const host = getObsidianExcalidrawHost();
+  if (host) {
+    return host.isDoubleClickTextEditingDisabled() ?? false;
+  }
   return getHostPlugin().settings.disableDoubleClickTextEditing ?? false;
 };
 
 // zoomStep: number;        // % increment per zoom action (e.g. mouse wheel)
 //  zoomMin: number;         // minimum zoom percentage
 //  zoomMax: number;         // maximum zoom percentage
-export const getZoomStep = () => getHostPlugin().settings.zoomStep ?? ZOOM_STEP;
-export const getZoomMin = () => getHostPlugin().settings.zoomMin ?? MIN_ZOOM;
-export const getZoomMax = () => getHostPlugin().settings.zoomMax ?? MAX_ZOOM;
+export const getZoomStep = () => {
+  const host = getObsidianExcalidrawHost();
+  return host
+    ? host.getZoomStep() ?? ZOOM_STEP
+    : getHostPlugin().settings.zoomStep ?? ZOOM_STEP;
+};
+export const getZoomMin = () => {
+  const host = getObsidianExcalidrawHost();
+  return host
+    ? host.getZoomMin() ?? MIN_ZOOM
+    : getHostPlugin().settings.zoomMin ?? MIN_ZOOM;
+};
+export const getZoomMax = () => {
+  const host = getObsidianExcalidrawHost();
+  return host
+    ? host.getZoomMax() ?? MAX_ZOOM
+    : getHostPlugin().settings.zoomMax ?? MAX_ZOOM;
+};
 
 export const runAction = (action: string): void => {
   getHostPlugin()?.runAction(action);
@@ -348,6 +388,10 @@ export const isFullPanelMode = (app: AppClassProperties): boolean => {
 };
 
 export const isContextMenuDisabled = (): boolean => {
+  const host = getObsidianExcalidrawHost();
+  if (host) {
+    return host.isContextMenuDisabled() ?? false;
+  }
   return getHostPlugin().settings.disableContextMenu ?? false;
 };
 
@@ -463,5 +507,9 @@ export const attachInlineLinkSuggester = (
   );
 
 export const syncElementLinkWithText = (): boolean => {
+  const host = getObsidianExcalidrawHost();
+  if (host) {
+    return host.shouldSyncElementLinkWithText() ?? true;
+  }
   return getHostPlugin().settings.syncElementLinkWithText ?? true;
 };

--- a/packages/excalidraw/obsidianUtils.ts
+++ b/packages/excalidraw/obsidianUtils.ts
@@ -15,7 +15,6 @@ import { FONT_METADATA } from "@excalidraw/common";
 import { intersectElementWithLineSegment } from "@excalidraw/element/collision";
 import { lineSegment } from "@excalidraw/math";
 
-
 import {
   getLineHeightInPx,
   isArrowElement,
@@ -24,8 +23,6 @@ import {
   ShapeCache,
   updateBoundPoint,
 } from "@excalidraw/element";
-
-import { getHostPlugin } from "@excalidraw/common/commonObsidianUtils";
 
 import type { Scene, Store } from "@excalidraw/element";
 
@@ -41,84 +38,34 @@ import type {
   NonDeletedExcalidrawElement,
 } from "@excalidraw/element/types";
 
-import type { MermaidConfig } from "@excalidraw/mermaid-to-excalidraw";
-
-import type { MermaidToExcalidrawResult } from "@excalidraw/mermaid-to-excalidraw/dist/interfaces";
-
 import { Fonts } from "./fonts";
 import { loadMermaidLib } from "./components/TTDDialog/MermaidToExcalidrawLib";
 import { getObsidianExcalidrawHost } from "./obsidianExcalidrawHost";
 
+import type { ObsidianKeyBlocker } from "./obsidianExcalidrawHost";
+import type { MermaidToExcalidrawLibProps } from "./components/TTDDialog/types";
+
 import type { AppClassProperties, AppState } from "./types";
 
-interface MermaidToExcalidrawLibProps {
-  loaded: boolean;
-  api: Promise<{
-    parseMermaidToExcalidraw: (
-      definition: string,
-      config?: MermaidConfig,
-    ) => Promise<MermaidToExcalidrawResult>;
-  }>;
-}
-
 export function allowDoubleTapEraser() {
-  const host = getObsidianExcalidrawHost();
-  if (host) {
-    return host.isDoubleTapEraserEnabled();
-  }
-  return getHostPlugin().settings.penModeDoubleTapEraser;
+  return getObsidianExcalidrawHost()?.isDoubleTapEraserEnabled() ?? false;
 }
 
 //mfuria #329. Enable panning with right mouse button if host plugin setting allows
 export function isPanWithRightMouseEnabled(): boolean {
   try {
-    const host = getObsidianExcalidrawHost();
-    if (host) {
-      return !!host.isRightClickPanEnabled();
-    }
-    return !!getHostPlugin().settings?.panWithRightMouseButton;
+    return !!getObsidianExcalidrawHost()?.isRightClickPanEnabled();
   } catch (e) {
     return false;
   }
 }
 
 export function getMaxZoom(): number {
-  const host = getObsidianExcalidrawHost();
-  if (host) {
-    return host.getZoomToFitMaxLevel() ?? 1;
-  }
-  return getHostPlugin().settings.zoomToFitMaxLevel ?? 1;
-}
-
-export function isExcaliBrainView() {
-  const excalidrawView = getHostPlugin().activeExcalidrawView;
-  if (!excalidrawView) {
-    return false;
-  }
-  return (
-    excalidrawView.linksAlwaysOpenInANewPane &&
-    excalidrawView.allowFrameButtonsInViewMode
-  );
-}
-
-export function getExcalidrawContentEl(): HTMLElement {
-  const excalidrawView = getHostPlugin().activeExcalidrawView;
-  if (!excalidrawView) {
-    return document.body;
-  }
-  return excalidrawView.contentEl as HTMLElement;
+  return getObsidianExcalidrawHost()?.getZoomToFitMaxLevel() ?? 1;
 }
 
 export function hideFreedrawPenmodeCursor() {
-  const host = getObsidianExcalidrawHost();
-  if (host) {
-    return !host.isPenModeCrosshairVisible();
-  }
-  return !getHostPlugin().settings.penModeCrosshairVisible;
-}
-
-export function getOpenAIDefaultVisionModel() {
-  return getHostPlugin().settings.openAIDefaultVisionModel;
+  return !(getObsidianExcalidrawHost()?.isPenModeCrosshairVisible() ?? true);
 }
 
 export function getFontMetrics(
@@ -275,7 +222,9 @@ export async function fetchFontFromVault(
     const filename = decodeURIComponent(
       url.substring(url.lastIndexOf("/") + 1),
     );
-    const arrayBuffer = await getHostPlugin().loadFontFromFile(filename);
+    const arrayBuffer = await getObsidianExcalidrawHost()?.loadFontFromFile(
+      filename,
+    );
     if (arrayBuffer) {
       return arrayBuffer;
     }
@@ -287,10 +236,8 @@ export function isTouchInPenMode(
   appState: AppState,
   event: React.PointerEvent<HTMLElement> | MouseEvent,
 ) {
-  const host = getObsidianExcalidrawHost();
-  const isSingleFingerPanningEnabled = host
-    ? host.isSingleFingerPanningEnabled()
-    : getHostPlugin().settings.penModeSingleFingerPanning;
+  const isSingleFingerPanningEnabled =
+    getObsidianExcalidrawHost()?.isSingleFingerPanningEnabled() ?? false;
   if (!isSingleFingerPanningEnabled) {
     return false;
   }
@@ -304,7 +251,11 @@ export function isTouchInPenMode(
 }
 
 export async function getSharedMermaidInstance(): Promise<MermaidToExcalidrawLibProps> {
-  return await getHostPlugin().getMermaid();
+  const host = getObsidianExcalidrawHost();
+  if (!host) {
+    throw new Error("Obsidian Excalidraw host is not configured");
+  }
+  return await host.getMermaid();
 }
 
 export async function loadMermaid(): Promise<MermaidToExcalidrawLibProps> {
@@ -332,41 +283,30 @@ export const intersectElementWithLine = (
 
 //disable double click
 export const disableDoubleClickTextEditing = () => {
-  const host = getObsidianExcalidrawHost();
-  if (host) {
-    return host.isDoubleClickTextEditingDisabled() ?? false;
-  }
-  return getHostPlugin().settings.disableDoubleClickTextEditing ?? false;
+  return (
+    getObsidianExcalidrawHost()?.isDoubleClickTextEditingDisabled() ?? false
+  );
 };
 
 // zoomStep: number;        // % increment per zoom action (e.g. mouse wheel)
 //  zoomMin: number;         // minimum zoom percentage
 //  zoomMax: number;         // maximum zoom percentage
 export const getZoomStep = () => {
-  const host = getObsidianExcalidrawHost();
-  return host
-    ? host.getZoomStep() ?? ZOOM_STEP
-    : getHostPlugin().settings.zoomStep ?? ZOOM_STEP;
+  return getObsidianExcalidrawHost()?.getZoomStep() ?? ZOOM_STEP;
 };
 export const getZoomMin = () => {
-  const host = getObsidianExcalidrawHost();
-  return host
-    ? host.getZoomMin() ?? MIN_ZOOM
-    : getHostPlugin().settings.zoomMin ?? MIN_ZOOM;
+  return getObsidianExcalidrawHost()?.getZoomMin() ?? MIN_ZOOM;
 };
 export const getZoomMax = () => {
-  const host = getObsidianExcalidrawHost();
-  return host
-    ? host.getZoomMax() ?? MAX_ZOOM
-    : getHostPlugin().settings.zoomMax ?? MAX_ZOOM;
+  return getObsidianExcalidrawHost()?.getZoomMax() ?? MAX_ZOOM;
 };
 
-export const runAction = (action: string): void => {
-  getHostPlugin()?.runAction(action);
+export const runAction = (action: "anyFile" | "LaTeX" | "card"): void => {
+  getObsidianExcalidrawHost()?.runAction(action);
 };
 
 export const t2 = (key: string): string => {
-  return getHostPlugin()?.getLabel(key) ?? key;
+  return getObsidianExcalidrawHost()?.getLabel(key) ?? key;
 };
 
 export const shouldDisableZoom = (appState: AppState): boolean => {
@@ -388,11 +328,7 @@ export const isFullPanelMode = (app: AppClassProperties): boolean => {
 };
 
 export const isContextMenuDisabled = (): boolean => {
-  const host = getObsidianExcalidrawHost();
-  if (host) {
-    return host.isContextMenuDisabled() ?? false;
-  }
-  return getHostPlugin().settings.disableContextMenu ?? false;
+  return getObsidianExcalidrawHost()?.isContextMenuDisabled() ?? false;
 };
 
 export const refreshAllArrows = (scene: Scene, store: Store) => {
@@ -467,7 +403,8 @@ export const refreshAllArrows = (scene: Scene, store: Store) => {
 
     LinearElementEditor.movePoints(el, scene, pointUpdates, {
       moveMidPointsWithElement:
-        !!startBindingElement && startBindingElement?.id === endBindingElement?.id,
+        !!startBindingElement &&
+        startBindingElement?.id === endBindingElement?.id,
     });
 
     ShapeCache.delete(el);
@@ -480,36 +417,32 @@ export const refreshAllArrows = (scene: Scene, store: Store) => {
   }
 };
 
-interface KeyBlocker {
-  isBlockingKeys(): boolean;
-  close(): void;
-}
-
 /**
-   * Attaches an inline link suggester to the specified input element.
-   * @param inputEl The HTML input element to attach the suggester to.
-   * @param widthWrapper Optional HTML element to wrap the width of suggester element.
-   * @param containerEl Optional container element used as collision boundary.
-   * @param surpessPlaceholder Whether to suppress the placeholder text. Defaults to true.
-   * @returns A KeyBlocker instance for managing keyboard input.
-   */
+ * Attaches an inline link suggester to the specified input element.
+ * @param inputEl The HTML input element to attach the suggester to.
+ * @param widthWrapper Optional HTML element to wrap the width of suggester element.
+ * @param container Optional container element used as collision boundary.
+ * @param surpessPlaceholder Whether to suppress the placeholder text. Defaults to true.
+ * @returns A keyboard-blocking lifecycle for managing keyboard input.
+ */
 export const attachInlineLinkSuggester = (
-  inputEl: HTMLInputElement|HTMLTextAreaElement,
+  inputEl: HTMLInputElement | HTMLTextAreaElement,
   widthWrapper?: HTMLElement,
   container: HTMLDivElement | null = null,
   surpessPlaceholder: boolean = true,
-): KeyBlocker =>
-  getHostPlugin().attachInlineLinkSuggester(
+): ObsidianKeyBlocker => {
+  const host = getObsidianExcalidrawHost();
+  if (!host) {
+    throw new Error("Obsidian Excalidraw host is not configured");
+  }
+  return host.attachInlineLinkSuggester(
     inputEl,
     widthWrapper,
     container,
     surpessPlaceholder,
   );
+};
 
 export const syncElementLinkWithText = (): boolean => {
-  const host = getObsidianExcalidrawHost();
-  if (host) {
-    return host.shouldSyncElementLinkWithText() ?? true;
-  }
-  return getHostPlugin().settings.syncElementLinkWithText ?? true;
+  return getObsidianExcalidrawHost()?.shouldSyncElementLinkWithText() ?? true;
 };

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zsviczian/excalidraw",
-  "version": "0.18.123",
+  "version": "0.18.124",
   "type": "module",
   "main": "./dist/prod/index.js",
   "module": "./dist/prod/index.js",


### PR DESCRIPTION
## Summary

- replace raw Obsidian plugin discovery and caching with versioned, typed host adapters
- route common device, UI, canvas-limit, and highlight capabilities through the common adapter
- route package settings, vault fonts, Mermaid, actions, labels, and inline-link suggestions through the Excalidraw adapter
- register adapters per evaluated window runtime with idempotent, stale-safe teardown
- remove dead active-view/AI helpers and use the owning editor container for frame-name layout
- bump the fork package to 0.18.124

Companion plugin PR: https://github.com/zsviczian/obsidian-excalidraw-plugin/pull/2895

## Validation

- focused Vitest suites: 18/18 passed without an Obsidian runtime
- common ESM/type build passed
- Obsidian artifact and declaration builds passed
- full package prepack passed
- npm tarball contains the four required Obsidian artifacts and both host declarations
- coordinated plugin production build and main-window/popout smoke testing passed