### PR TITLE
Improve cached embedded drawing loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,25 @@ When changing a menu or popover:
 - Search all imports, callers, styles, tests, and package exports before changing a shared component or type.
 - Do not add network dependencies or remote code loading. The host-provided Mermaid integration is not a network loader; lazy CJK asset fetching is the narrowly scoped network exception and is not precedent for other assets.
 
+### Trusted Optimization Bypasses
+
+An optimization that skips normal validation, normalization, or sanitization
+must retain the safe path as the default.
+
+- Make authorization call-scoped and ephemeral. Do not persist a `trusted`,
+  `normalized`, or equivalent marker in scene data or `BinaryFileData` merely
+  to avoid repeated work.
+- Require the host that produced or inspected the payload to identify the
+  eligible inputs. Inputs absent from that explicit authorization must execute
+  the unchanged safe path.
+- Preserve the existing API call form when doing so is inexpensive. Add an
+  options form rather than forcing unrelated consumers to change.
+- Keep the bypass narrow enough that its complete data flow can be reviewed:
+  who certifies it, how identity is matched, how long authorization lives, and
+  where the normal path remains intact.
+- Test both a certified input and an ordinary/untrusted input. A faster trusted
+  case is not sufficient evidence that the fallback still works.
+
 ## Validation
 
 Use Node.js 22 or newer and Yarn. If `yarn` invokes a different Node installation through Corepack, fix the toolchain before attributing the failure to source code.
@@ -186,6 +205,13 @@ For integration validation:
 2. Run `npm run build` in the plugin repository. Run `npm run dev` too when debugger payloads or development CSS changed.
 3. Test cold startup, plugin reload, normal editing, main-window and popout behavior, popout teardown, offline operation, and the feature-specific workflow. For adapter settings, confirm a setting changed after registration is observed without recreating the runtime.
 4. Record the plugin `dist/main.js` byte size after component or packaging changes.
+
+Copying local artifacts proves only the unpublished integration checkpoint. If
+the plugin source consumes a new fork API, the plugin's durable handoff is not
+commit-ready until the published package containing that API is installed and
+the plugin's exact dependency and lockfile are updated. A maintainer may still
+request an explicitly paired intermediate commit, but it must not be described
+as release-ready.
 
 End every handoff with a risk-based manual test list. State the most likely regression and which platforms/windows require separate testing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,12 @@ These adapters form an internal protocol paired with the plugin's exact package 
 
 The normal upstream ESM package and the Obsidian consumer artifact serve different purposes. Keep the Obsidian build isolated and semantically named; do not restore the retired UMD/webpack path.
 
+An optimization that bypasses normal validation or normalization must be
+explicitly authorized for each call. Keep the safe behavior as the default,
+let the host identify only the inputs it generated or verified, and do not
+persist trust markers in scene or binary-file data. Preserve the legacy call
+form when practical and test both the authorized and ordinary paths.
+
 From `packages/excalidraw`, run:
 
 ```bash
@@ -191,6 +197,12 @@ When changing Radix menus, popovers, or `ObsidianRadixPortal`, test the main win
 ## Cross-Repository Integration Testing
 
 The plugin consumes these files from `node_modules/@zsviczian/excalidraw/dist/obsidian/`. Before publishing a new package, the four locally generated files may be copied temporarily into the sibling plugin's ignored installed package for integration testing. Keep the plugin's declared dependency unchanged during this temporary handoff; `npm install` restores the published artifact.
+
+Treat three states separately: the component source may be ready to commit; a
+local artifact copy may prove cross-repository integration; and the consumer
+handoff becomes durable only after the published package is installed and the
+plugin dependency and lockfile reference that version. Do not describe the
+second state as a release-ready plugin commit.
 
 Host-boundary unit tests do not load Obsidian or the plugin. Use structural fake adapters to test standalone defaults or required-service errors, capability forwarding, protocol rejection, idempotent cleanup, and stale-disposer safety. Cross-repository testing is the separate integration gate for actual plugin registration, reload, main-window and popout lifecycle, and live settings reads.
 

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5521,14 +5521,25 @@ class App extends React.Component<AppProps, AppState> {
    * NOTE if file already exists in editor state, the file data is not updated
    * */
   public addFiles: ExcalidrawImperativeAPI["addFiles"] = withBatchedUpdates(
-    (files) => {
-      const { addedFiles } = this.addMissingFiles(files, undefined, true); //zsviczian
+    // zsviczian START -- accept caller-certified SVGs without repeat normalization
+    (data) => {
+      const files = Array.isArray(data) ? data : data.files;
+      const skipSvgNormalization = Array.isArray(data)
+        ? undefined
+        : data.skipSvgNormalization;
+      const { addedFiles } = this.addMissingFiles(
+        files,
+        undefined,
+        true,
+        skipSvgNormalization,
+      );
 
       this.clearImageShapeCache(addedFiles);
       this.scene.triggerUpdate();
 
       this.addNewImagesToImageCache();
     },
+    // zsviczian END
   );
 
   //zsviczian https://github.com/zsviczian/excalibrain/issues/9
@@ -5624,6 +5635,7 @@ class App extends React.Component<AppProps, AppState> {
     files: BinaryFiles | BinaryFileData[],
     replace = false,
     force = false, //zsviczian
+    skipSvgNormalization?: ReadonlySet<FileId>, // zsviczian -- caller-certified SVG IDs
   ) => {
     const nextFiles = replace ? {} : { ...this.files };
     const addedFiles: BinaryFiles = {};
@@ -5639,7 +5651,8 @@ class App extends React.Component<AppProps, AppState> {
       addedFiles[fileData.id] = fileData;
       nextFiles[fileData.id] = fileData;
 
-      if (fileData.mimeType === MIME_TYPES.svg) {
+      const shouldNormalizeSVG = !skipSvgNormalization?.has(fileData.id); // zsviczian -- caller-certified SVG bypass
+      if (fileData.mimeType === MIME_TYPES.svg && shouldNormalizeSVG) {
         try {
           const restoredDataURL = getDataURL_sync(
             normalizeSVG(dataURLToString(fileData.dataURL)),

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zsviczian/excalidraw",
-  "version": "0.18.124",
+  "version": "0.18.125",
   "type": "module",
   "main": "./dist/prod/index.js",
   "module": "./dist/prod/index.js",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -1369,7 +1369,17 @@ export interface ExcalidrawImperativeAPI {
   registerAction: (action: Action) => void;
   refresh: InstanceType<typeof App>["refresh"];
   setToast: InstanceType<typeof App>["setToast"];
-  addFiles: (data: BinaryFileData[]) => void;
+  // zsviczian START -- let the Obsidian host identify trusted, already-normalized SVGs without persisting a marker
+  addFiles: (
+    data:
+      | BinaryFileData[]
+      | {
+          files: BinaryFileData[];
+          /** IDs of host-generated SVGs that already satisfy Excalidraw's normalization contract. */
+          skipSvgNormalization?: ReadonlySet<FileId>;
+        },
+  ) => void;
+  // zsviczian END
   updateContainerSize: InstanceType<typeof App>["updateContainerSize"]; //zsviczian
   id: string;
   selectElements: (


### PR DESCRIPTION
## Summary
- allow the Obsidian host to identify generated SVGs that do not need repeat normalization
- preserve the legacy addFiles array form and normal handling for arbitrary SVGs
- document trusted optimization bypasses and durable cross-repository handoffs
- bump @zsviczian/excalidraw to 0.18.125

## Validation
- yarn build:obsidian
- focused ESLint has no findings in the touched ranges
- plugin integration build passed against the published package
- repository-wide typecheck retains only the documented pre-existing test-harness backlog